### PR TITLE
Use sparse matrix for all "big" matrices (mass consistent and stiffness)

### DIFF
--- a/Problem.h
+++ b/Problem.h
@@ -34,9 +34,8 @@ private:
     SquareLinearMesh* problem_mesh;
     MaterialModel* control;
     arma::mat* ricker_pulse; 
-    arma::mat* global_stiffness_consistent;
-    arma::sp_mat global_stiffness_sparse;
-    arma::mat* global_mass_consistent;
+    arma::sp_mat* global_stiffness_consistent;
+    arma::sp_mat* global_mass_consistent;
     arma::mat* global_mass;
     std::vector<Device> receivers;
     std::vector<Device> sources;


### PR DESCRIPTION
Removed previous code. I'm now using sparse matrices everywhere possible, due to memory issues with problems >200x200 on my machine. Memory issues are not happening after the changes in this PR.